### PR TITLE
Drop Puppet < 6.1.0 compatibility code

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -174,12 +174,6 @@ class etcd (
     notify  => Service['etcd'],
   }
 
-  if versioncmp($facts['puppetversion'],'6.1.0') < 0 {
-    # Puppet 5 does not execute 'systemctl daemon-reload' automatically (https://tickets.puppetlabs.com/browse/PUP-3483)
-    # and camptocamp/systemd only creates this relationship when managing the service
-    Class['systemd::systemctl::daemon_reload'] -> Service['etcd']
-  }
-
   service { 'etcd':
     ensure => 'running',
     enable => true,


### PR DESCRIPTION
metadata.json requires Puppet 7 or newer.